### PR TITLE
ssh-copy-id.sh: empty ssh-agent on Snow Leopard

### DIFF
--- a/ssh-copy-id.sh
+++ b/ssh-copy-id.sh
@@ -20,7 +20,7 @@ if [ "-i" = "$1" ]; then
   fi
 else
   if [ x$SSH_AUTH_SOCK != x ] ; then
-    GET_ID="$GET_ID ssh-add -L"
+    GET_ID="$GET_ID ssh-add -L | grep -vxF 'The agent has no identities.'"
   fi
 fi
 


### PR DESCRIPTION
On Snow Leopard, ssh-add -L outputs a warning to stdout when the agent has no identities. Compensate for this by removing the warning from the output with grep.
