### PR TITLE
fixed broken url in instrucctions

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -7,7 +7,7 @@ Git clone & run install script
 
 OR
 
-curl https://raw.github.com/beautifulcode/ssh-copy-id-for-OSX/master/ssh-copy-id.sh -o /usr/local/bin/ssh-copy-id
+curl https://raw.githubusercontent.com/beautifulcode/ssh-copy-id-for-OSX/master/ssh-copy-id.sh -o /usr/local/bin/ssh-copy-id
 chmod +x /usr/local/bin/ssh-copy-id
 
 


### PR DESCRIPTION
The current domain to access raw files is
https://raw.githubusercontent.com
