### PR TITLE
README.txt updates

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -7,7 +7,7 @@ Git clone & run install script
 
 OR
 
-curl https://raw.githubusercontent.com/beautifulcode/ssh-copy-id-for-OSX/master/install.sh | sh
+curl -L https://raw.githubusercontent.com/beautifulcode/ssh-copy-id-for-OSX/master/install.sh | sh
 
 
 


### PR DESCRIPTION
The original `README.txt` advises users to download the script using `curl`, but GitHub is responding with a `HTTP 301` to the new location:

```
$ curl https://raw.github.com/beautifulcode/ssh-copy-id-for-OSX/master/ssh-copy-id.sh -I
HTTP/1.1 301 Moved Permanently
Date: Wed, 25 Jun 2014 19:19:57 GMT
Server: Apache
Location: https://raw.githubusercontent.com/beautifulcode/ssh-copy-id-for-OSX/master/ssh-copy-id.sh
Accept-Ranges: bytes
Via: 1.1 varnish
Age: 0
X-Served-By: cache-lcy1124-LCY
X-Cache: MISS
X-Cache-Hits: 0
Vary: Accept-Encoding
```

Thus, installation fails _silently_.
- I've updated `README.txt` to use new GitHub URL. ae5e08d
- Updated `README.txt` to advise users to supply the `-L` option to `curl`, which follows HTTP redirects and therefore stops the above issue reoccurring, should the URL change again. 643e6b3
- I've also prefixed the installation commands with `sudo`, as this is required for a normal user to install into `/usr/local/bin`. 79f12f2
